### PR TITLE
Add Tempo column to playlist songs table

### DIFF
--- a/app.js
+++ b/app.js
@@ -125,6 +125,15 @@ const APIController = (function() {
         return allTracks; // return object containing list of tracks
     }
 
+    const getTrackAudioFeatures = async (trackID) => {
+        // https://api.spotify.com/v1/audio-features/{id}
+        const result = await fetch(apiBaseURL + "audio-features/" + trackID, {
+            method: 'GET',
+            headers: {'Authorization': `Bearer ${session.access_token}`}
+        });
+        return await result.json();
+    }
+
     const getTrackArtistsArray = (track) => { // returns an array of a track's artists, in the form of URLs to their pages on Spotify
         let arr = [];
         for (let artist of track.artists) { // add the URL of each artist to an array
@@ -350,7 +359,8 @@ const APIController = (function() {
                     album: getTrackAlbumURL(track.track),
                     date_added: formatTimestamp(track.added_at),
                     release_date: getTrackReleaseDate(track.track),
-                    duration: formatDuration(track.track.duration_ms)
+                    duration: formatDuration(track.track.duration_ms),
+                    tempo: (await getTrackAudioFeatures(track.track.id)).tempo
                 };
                 tooltipData[i] = { // prepare data for point hover tooltips
                     name: track.track.name,

--- a/views/display.ejs
+++ b/views/display.ejs
@@ -50,13 +50,14 @@
         <h2>Tracks:</h2>
         <table id="tracks_table">
             <tr>
-                <th title="Click to Sort by Track No." onClick="sortTable(0)">#</th>
+                <th title="Click to Sort by Track No." onClick="sortTable(0, true)">#</th>
                 <th title="Click to Sort Alphabetically by Track Name" onClick="sortTable(1)">Track</th>
                 <th title="Click to Sort Alphabetically by Artist Name" colspan="<%= max_artists %>" onClick="sortTable(2)">Artists</th> <!-- Dynamic column width, depending on max no. of artists -->
                 <th title="Click to Sort Alphabetically by Album Name" onClick="sortTable(<%= max_artists + 2 %>)">Album</th>
                 <th title="Click to Sort by Date Added" onClick="sortTable(<%= max_artists + 3 %>)">Date Added</th>
                 <th title="Click to Sort by Release Date" onClick="sortTable(<%= max_artists + 4 %>)">Release Date</th>
                 <th title="Click to Sort by Duration" onClick="sortTable(<%= max_artists + 5 %>)">Duration</th>
+                <th title="Click to Sort by Tempo" onClick="sortTable(<%= max_artists + 6 %>, true)">Tempo</th>
             </tr>
         <% for (var i = 0; i < display_data.length; i++) { %>
             <tr>
@@ -72,6 +73,7 @@
                 <td><%= display_data[i].date_added %></td>
                 <td><%= display_data[i].release_date %></td>
                 <td><%- display_data[i].duration %></td>
+                <td><%- display_data[i].tempo %></td>
             </tr>
         <% } %>
         </table>
@@ -121,7 +123,7 @@
         // if negative, it is in DESCENDING order
         // if positive, it is in ASCENDING order
 
-        const TABLE_HEADINGS = ["#", "Track", "Artists", "Album", "Date Added", "Release Date", "Duration"];
+        const TABLE_HEADINGS = ["#", "Track", "Artists", "Album", "Date Added", "Release Date", "Duration", "Tempo (BPM)"];
 
         // get document elements
         const canvas = document.getElementById('chart');
@@ -305,7 +307,7 @@
             location.reload();
         });
 
-        function sortTable(columnIndex) {
+        function sortTable(columnIndex, numeric=false) {
             const table = document.getElementById("tracks_table");
             const headings = table.rows[0];
             const rows = Array.from(table.rows).slice(1); // Get all rows except the header
@@ -329,7 +331,7 @@
                 let cellA = rowA.cells[indexToSort].innerText.toLowerCase();
                 let cellB = rowB.cells[indexToSort].innerText.toLowerCase();
 
-                if (indexToSort === 0) { // for the '#' column, sort numerically, not alphabetically
+                if (numeric) { // for the '#' column, sort numerically, not alphabetically
                     cellA = parseInt(cellA);
                     cellB = parseInt(cellB);
                 }


### PR DESCRIPTION
```js
const getTrackAudioFeatures = async (trackID) => {
        // https://api.spotify.com/v1/audio-features/{id}
        const result = await fetch(apiBaseURL + "audio-features/" + trackID, {
            method: 'GET',
            headers: {'Authorization': `Bearer ${session.access_token}`}
        });
        return await result.json();
}
```

I've added a function which calls the `https://api.spotify.com/v1/audio-features/{id}` endpoint documented [here](https://developer.spotify.com/documentation/web-api/reference/get-audio-features), and this function is invoked for each song to populate the newly added "Tempo (BPM)" column in the table as shown in the preview below.

Preview
![image](https://github.com/user-attachments/assets/603402ca-6289-41cf-8e4b-1cef253dbbec)

I've also added an optional `numeric` parameter to the `sortTable` function signature: `function sortTable(columnIndex, numeric=false)`. This means certain columns can easily be treated as numeric and be sorted numerically as opposed to alphabetically, and indexes don't need to be hard-coded into the `sortTable` function.